### PR TITLE
Add scripts to precompute structures

### DIFF
--- a/ocdata/base_atoms/pkls/__init__.py
+++ b/ocdata/base_atoms/pkls/__init__.py
@@ -2,4 +2,6 @@ import os
 
 
 BULK_PKL = os.path.join(__path__[0], 'bulks.pkl')
+MAY12_BULK_PKL = os.path.join(__path__[0], 'bulks_may12.pkl')
 ADSORBATE_PKL = os.path.join(__path__[0], 'adsorbates.pkl')
+MAY12_SURFACE_ENUM_PKL = os.path.join(__path__[0], 'for_surface_enumeration_bulk_may12.pkl')

--- a/ocdata/base_atoms/pkls/convert_db_to_pkl.py
+++ b/ocdata/base_atoms/pkls/convert_db_to_pkl.py
@@ -9,7 +9,7 @@ import ase.db
 import pickle
 
 
-def convert_bulk(input_bulk_database, max_num_elements, output_pkl):
+def get_bulk_inverted_index_1(input_bulk_database, max_num_elements):
     '''
     Converts an input ASE.db to an inverted index to efficiently sample bulks
     '''
@@ -21,15 +21,83 @@ def convert_bulk(input_bulk_database, max_num_elements, output_pkl):
     for i in range(1, max_num_elements + 1):
         index[i] = []
         rows = list(db.select(n_elements=i))
+        print(len(rows))
         for r in range(len(rows)):
             index[i].append((rows[r].toatoms(), rows[r].mpid))
             total_entries += 1
-    with open(output_pkl, 'wb') as f:
-        pickle.dump(index, f)
+
+    return index, total_entries
+
+def get_bulk_inverted_index_2(input_bulk_database, max_num_elements):
+    '''
+    Converts an input ASE.db to an inverted index to efficiently sample bulks
+    '''
+    assert max_num_elements > 0
+    db = ase.db.connect(input_bulk_database)
+    rows = list(db.select())
+
+    index = {}
+    total_entries = 0
+    for r in range(len(rows)):
+        bulk = rows[r].toatoms()
+        mpid = rows[r].mpid
+        formula_str = str(bulk.symbols)
+        num_ele = sum(1 for c in formula_str if c.isupper())
+        if num_ele > max_num_elements:
+            continue
+        if num_ele not in index:
+            index[num_ele] = []
+        index[num_ele].append((bulk, mpid))
+        total_entries += 1
+
+    return index, total_entries
+
+
+# handling 2 dbs 
+def convert_bulk(bulk_path1, bulk_path2, max_num_elements, output_pkl, precompute_pkl_for_surface_enumeration):
+
+    index1, total_entries1 = get_bulk_inverted_index_1(bulk_path1, max_num_elements)
+    index2, total_entries2 = get_bulk_inverted_index_2(bulk_path2, max_num_elements)
 
     # As of bulk.db file from Kevin on 01 May 2020
-    assert total_entries == 11010
+    assert total_entries1 == 11010
+    assert total_entries2 == 491
+    
+    combined_total_entries = total_entries1 + total_entries2
+    lst_for_surface_enumeration = []
+    combined_index = {}
+    all_index_counter = 0
 
+    # Handle first db elements
+    for i in range(1, max_num_elements + 1):
+        combined_index[i] = []
+
+        for j in range(len(index1[i])):
+            sampling_str = str(j) + "/" + str(len(index1[i])) + "_" + str(all_index_counter) + "/11010"
+            bulk, mpid = index1[i][j]
+            current_obj = (bulk, mpid, sampling_str, all_index_counter)
+            print(current_obj)
+            combined_index[i].append(current_obj)
+            all_index_counter += 1
+            lst_for_surface_enumeration.append(current_obj)
+
+    # Handle second db elements
+    for i in range(1, max_num_elements + 1):
+        for j in range(len(index2[i])):
+            sampling_str = str(j + len(index1[i])) + "/"  + str(len(index1[i]) + len(index2[i])) + "_" + str(all_index_counter) + "/" + str(combined_total_entries)
+            bulk, mpid = index2[i][j]
+            current_obj = (bulk, mpid, sampling_str, all_index_counter)
+            print(current_obj)
+            combined_index[i].append(current_obj)
+            all_index_counter += 1
+            lst_for_surface_enumeration.append(current_obj)
+
+    with open(output_pkl, 'wb') as f:
+        pickle.dump(combined_index, f)
+
+    with open(precompute_pkl_for_surface_enumeration, 'wb') as g:
+        pickle.dump(lst_for_surface_enumeration, g)
+    
 
 def convert_adsorbate(input_adsorbate_database, output_pkl):
     '''
@@ -54,8 +122,8 @@ def convert_adsorbate(input_adsorbate_database, output_pkl):
 
 
 def main():
-    convert_bulk("../ase_dbs/bulks.db", 3, "bulks.pkl")
-    convert_adsorbate("../ase_dbs/adsorbates.db", "adsorbates.pkl")
+    convert_bulk("../ase_dbs/bulks.db", "../ase_dbs/new_bulks.db", 3, "bulks_may12.pkl", "for_surface_enumeration_bulk_may12.pkl")
+#    convert_adsorbate("../ase_dbs/adsorbates.db", "adsorbates.pkl")
 
 
 if __name__ == "__main__":

--- a/ocdata/precompute_sample_structures.py
+++ b/ocdata/precompute_sample_structures.py
@@ -1,0 +1,173 @@
+'''
+This submodule contains the scripts that the we used to sample the adsorption
+structures.
+
+Note that some of these scripts were taken from
+[GASpy](https://github.com/ulissigroup/GASpy) with permission of author.
+'''
+
+__authors__ = ['Kevin Tran', 'Aini Palizhati', 'Siddharth Goyal', 'Zachary Ulissi']
+__email__ = ['ktran@andrew.cmu.edu']
+
+import math
+from collections import defaultdict
+import random
+import pickle
+import numpy as np
+import catkit
+import ase
+import ase.db
+from ase import neighborlist
+from ase.constraints import FixAtoms
+from ase.neighborlist import natural_cutoffs
+from pymatgen.io.ase import AseAtomsAdaptor
+from pymatgen.core.surface import SlabGenerator, get_symmetrically_distinct_miller_indices
+from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
+from pymatgen.analysis.local_env import VoronoiNN
+from base_atoms.pkls import BULK_PKL, ADSORBATE_PKL
+from .constants import MAX_MILLER
+import sys
+import time
+
+def enumerate_surfaces_for_saving(bulk_atoms, max_miller=MAX_MILLER):
+    '''
+    Enumerate all the symmetrically distinct surfaces of a bulk structure. It
+    will not enumerate surfaces with Miller indices above the `max_miller`
+    argument. Note that we also look at the bottoms of surfaces if they are
+    distinct from the top. If they are distinct, we flip the surface so the bottom
+    is pointing upwards.
+
+    Args:
+        bulk_atoms  `ase.Atoms` object of the bulk you want to enumerate
+                    surfaces from.
+        max_miller  An integer indicating the maximum Miller index of the surfaces
+                    you are willing to enumerate. Increasing this argument will
+                    increase the number of surfaces, but the surfaces will
+                    generally become larger.
+    Returns:
+        all_slabs_info  A list of 4-tuples containing:  `pymatgen.Structure`
+                        objects for surfaces we have enumerated, the Miller
+                        indices, floats for the shifts, and Booleans for "top".
+    '''
+    bulk_struct = standardize_bulk(bulk_atoms)
+
+    all_slabs_info = []
+    for millers in get_symmetrically_distinct_miller_indices(bulk_struct, MAX_MILLER):
+        slab_gen = SlabGenerator(initial_structure=bulk_struct,
+                                 miller_index=millers,
+                                 min_slab_size=7.,
+                                 min_vacuum_size=20.,
+                                 lll_reduce=False,
+                                 center_slab=True,
+                                 primitive=True,
+                                 max_normal_search=1)
+        slabs = slab_gen.get_slabs(tol=0.3,
+                                   bonds=None,
+                                   max_broken_bonds=0,
+                                   symmetrize=False)
+
+        # If the bottoms of the slabs are different than the tops, then we want
+        # to consider them, too
+        flipped_slabs_info = [(flip_struct(slab), millers, slab.shift, False)
+                              for slab in slabs if is_structure_invertible(slab) is False]
+
+        # Concatenate all the results together
+        slabs_info = [(slab, millers, slab.shift, True) for slab in slabs]
+        all_slabs_info.extend(slabs_info + flipped_slabs_info)
+    return all_slabs_info
+
+
+def standardize_bulk(atoms):
+    '''
+    There are many ways to define a bulk unit cell. If you change the unit cell
+    itself but also change the locations of the atoms within the unit cell, you
+    can get effectively the same bulk structure. To address this, there is a
+    standardization method used to reduce the degrees of freedom such that each
+    unit cell only has one "true" configuration. This function will align a
+    unit cell you give it to fit within this standardization.
+
+    Arg:
+        atoms   `ase.Atoms` object of the bulk you want to standardize
+    Returns:
+        standardized_struct     `pymatgen.Structure` of the standardized bulk
+    '''
+    struct = AseAtomsAdaptor.get_structure(atoms)
+    sga = SpacegroupAnalyzer(struct, symprec=0.1)
+    standardized_struct = sga.get_conventional_standard_structure()
+    return standardized_struct
+
+
+def is_structure_invertible(structure):
+    '''
+    This function figures out whether or not an `pymatgen.Structure` object has
+    symmetricity. In this function, the affine matrix is a rotation matrix that
+    is multiplied with the XYZ positions of the crystal. If the z,z component
+    of that is negative, it means symmetry operation exist, it could be a
+    mirror operation, or one that involves multiple rotations/etc. Regardless,
+    it means that the top becomes the bottom and vice-versa, and the structure
+    is the symmetric. i.e. structure_XYZ = structure_XYZ*M.
+
+    In short:  If this function returns `False`, then the input structure can
+    be flipped in the z-direction to create a new structure.
+
+    Arg:
+        structure   A `pymatgen.Structure` object.
+    Returns
+        A boolean indicating whether or not your `ase.Atoms` object is
+        symmetric in z-direction (i.e. symmetric with respect to x-y plane).
+    '''
+    # If any of the operations involve a transformation in the z-direction,
+    # then the structure is invertible.
+    sga = SpacegroupAnalyzer(structure, symprec=0.1)
+    for operation in sga.get_symmetry_operations():
+        xform_matrix = operation.affine_matrix
+        z_xform = xform_matrix[2, 2]
+        if z_xform == -1:
+            return True
+    return False
+
+
+def flip_struct(struct):
+    '''
+    Flips an atoms object upside down. Normally used to flip surfaces.
+
+    Arg:
+        atoms   `pymatgen.Structure` object
+    Returns:
+        flipped_struct  The same `ase.Atoms` object that was fed as an
+                        argument, but flipped upside down.
+    '''
+    atoms = AseAtomsAdaptor.get_atoms(struct)
+
+    # This is black magic wizardry to me. Good look figuring it out.
+    atoms.wrap()
+    atoms.rotate(180, 'x', rotate_cell=True, center='COM')
+    if atoms.cell[2][2] < 0.:
+        atoms.cell[2] = -atoms.cell[2]
+    if np.cross(atoms.cell[0], atoms.cell[1])[2] < 0.0:
+        atoms.cell[1] = -atoms.cell[1]
+    atoms.wrap()
+
+    flipped_struct = AseAtomsAdaptor.get_structure(atoms)
+    return flipped_struct
+
+    
+def precompute_enumerate_surface(bulk_database, bulk_index, opfile):
+
+    with open(bulk_database, 'rb') as f:
+        inv_index = pickle.load(f)
+    flatten = inv_index[1] + inv_index[2] + inv_index[3]
+    assert bulk_index < len(flatten)
+
+    bulk, mpid = flatten[bulk_index] 
+
+    print(bulk, mpid)
+    surfaces_info = enumerate_surfaces_for_saving(bulk)
+
+    with open(opfile, 'wb') as g:
+        pickle.dump(surfaces_info, g)
+
+s = time.time()
+precompute_enumerate_surface(BULK_PKL, int(sys.argv[1]), sys.argv[2])
+e = time.time()
+print(sys.argv[1], "Done in", e - s )


### PR DESCRIPTION
These files were originally in branch `optimize_structure_sampling` and `refactor_enumerate_structures` (#11, #23), now split out because the other PRs were a different topic. Changes were originally made by @sidgoyal78.