### PR TITLE
Additional changes to sample_structure functionality

### DIFF
--- a/ocdata/bulk_obj.py
+++ b/ocdata/bulk_obj.py
@@ -19,14 +19,13 @@ class Bulk():
         self.precomputed_structures = precomputed_structures
         self.choose_bulk_pkl(bulk_database, bulk_index, max_elems)
 
-    def choose_bulk_pkl(self, inv_index, bulk_index, max_elems):
+    def choose_bulk_pkl(self, bulk_db, bulk_index, max_elems):
         '''
         Chooses a bulk from our pkl file at random as long as the bulk contains
         the specified number of elements in any composition.
 
         Args:
-            bulk_database   A string pointing to the pkl file that contains
-                            the bulks you want to consider.
+            bulk_db         Unpickled dict or list of bulks
             n_elems         An integer indicating how many elements should be
                             inside the bulk to be selected.
 
@@ -39,22 +38,22 @@ class Bulk():
 
         try:
             if bulk_index is not None:
-                assert len(inv_index) > 3, f'Bulk db only has {len(inv_index)} entries. Did you pass in the correct bulk database?'
-                assert isinstance(inv_index[bulk_index], tuple)
+                assert len(bulk_db) > 3, f'Bulk db only has {len(bulk_db)} entries. Did you pass in the correct bulk database?'
+                assert isinstance(bulk_db[bulk_index], tuple)
 
-                self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = inv_index[bulk_index]
+                self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = bulk_db[bulk_index]
                 self.n_elems = len(set(self.bulk_atoms.symbols)) # 1, 2, or 3
                 self.elem_sampling_str = f'{self.n_elems}/{max_elems}'
 
             else:
                 self.sample_n_elems()
-                assert isinstance(inv_index, dict), 'Did you pass in the correct bulk database?'
-                assert self.n_elems in inv_index.keys(), f'Bulk db does not have bulks of {self.n_elems} elements'
-                assert isinstance(inv_index[self.n_elems], list), 'Did you pass in the correct bulk database?'
+                assert isinstance(bulk_db, dict), 'Did you pass in the correct bulk database?'
+                assert self.n_elems in bulk_db.keys(), f'Bulk db does not have bulks of {self.n_elems} elements'
+                assert isinstance(bulk_db[self.n_elems], list), 'Did you pass in the correct bulk database?'
 
-                total_elements_for_key = len(inv_index[self.n_elems])
+                total_elements_for_key = len(bulk_db[self.n_elems])
                 row_bulk_index = np.random.choice(total_elements_for_key)
-                self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = inv_index[self.n_elems][row_bulk_index]
+                self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = bulk_db[self.n_elems][row_bulk_index]
 
         except IndexError:
             raise ValueError('Randomly chose to look for a %i-component material, '
@@ -62,24 +61,6 @@ class Bulk():
                              'to the database or change the weights to exclude '
                              'this number of components.'
                              % self.n_elems)
-
-    def find_n_elems_and_index(self, inv_index, bulk_index): ##### DEPRECATED, will remove #####
-        '''
-        Given the index of flattened inv_index, finds the n_elem and non-flattened index.
-        For example, if there are 100 bulks each of 1, 2, 3 elements, a bulk_index of 150
-        would obtain self.n_elems = 2 and returns row_bulk_index = 50
-
-        Sets n_elems and elem_sampling_str; returns row_bulk_index
-        '''
-        sorted_keys = sorted(inv_index.keys())
-        counts_cumul = np.cumsum([len(inv_index[key]) for key in sorted_keys])
-        assert bulk_index >= 0 and bulk_index < counts_cumul[-1], \
-            f'bulk index must be between 0 and {counts_cumul[-1] - 1} inclusive'
-
-        db_index = np.searchsorted(counts_cumul, bulk_index, side='right') # 0, 1, or 2
-        self.n_elems = sorted_keys[db_index] # 1, 2, or 3
-        self.elem_sampling_str = str(self.n_elems) + "/" + str(len(inv_index))
-        return bulk_index - counts_cumul[db_index]
 
     def sample_n_elems(self, n_cat_elems_weights={1: 0.05, 2: 0.65, 3: 0.3}): # TODO make these weights an input param?
         '''

--- a/ocdata/bulk_obj.py
+++ b/ocdata/bulk_obj.py
@@ -26,19 +26,20 @@ class Bulk():
 
         Args:
             bulk_db         Unpickled dict or list of bulks
-            n_elems         An integer indicating how many elements should be
-                            inside the bulk to be selected.
+            bulk_index      Index of which bulk to select. If None, randomly sample one.
+            max_elems       Max elems for any bulk structure. Currently it is 3 by default.
 
-        Sets:
-            bulk                        `ase.Atoms` of the chosen bulk structure.
+        Sets as class variables:
+            bulk_atoms                  `ase.Atoms` of the chosen bulk structure.
             mpid                        A string indicating which MPID the bulk is
-            index_in_flattened_array    Index of the chosen structure in the array
-            sampling_string             A string to enumerate the sampled structure
+            bulk_sampling_str           A string to enumerate the sampled structure
+            index_of_bulk_atoms         Index of the chosen bulk in the array (should match
+                                        bulk_index if provided)
         '''
 
         try:
             if bulk_index is not None:
-                assert len(bulk_db) > 3, f'Bulk db only has {len(bulk_db)} entries. Did you pass in the correct bulk database?'
+                assert len(bulk_db) > max_elems, f'Bulk db only has {len(bulk_db)} entries. Did you pass in the correct bulk database?'
                 assert isinstance(bulk_db[bulk_index], tuple)
 
                 self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = bulk_db[bulk_index]

--- a/ocdata/surfaces.py
+++ b/ocdata/surfaces.py
@@ -55,6 +55,9 @@ class Surface():
         self.tag_surface_atoms(self.bulk_object.bulk_atoms, self.surface_atoms)
         self.constrained_surface = constrain_surface(self.surface_atoms)
 
+        # verify that the bulk and surface elements match:
+        assert set(bulk_object.bulk_atoms.symbols) == set(self.surface_atoms.symbols)
+
     def tile_atoms(self, atoms): # todo style wise: better to put inside or outside of class?
         '''
         This function will repeat an atoms structure in the x and y direction until

--- a/ocdata/surfaces.py
+++ b/ocdata/surfaces.py
@@ -7,6 +7,7 @@ import pickle
 from ase import neighborlist
 from ase.constraints import FixAtoms
 from collections import defaultdict
+from pymatgen import Composition
 from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 from pymatgen.analysis.local_env import VoronoiNN
@@ -52,11 +53,14 @@ class Surface():
 
         unit_surface_atoms = AseAtomsAdaptor.get_atoms(surface_struct)
         self.surface_atoms = self.tile_atoms(unit_surface_atoms)
+
+        # verify that the bulk and surface elements and stoichiometry match:
+        assert (Composition(self.surface_atoms.get_chemical_formula()).reduced_formula ==
+            Composition(bulk_object.bulk_atoms.get_chemical_formula()).reduced_formula), \
+            'Mismatched bulk and surface'
+
         self.tag_surface_atoms(self.bulk_object.bulk_atoms, self.surface_atoms)
         self.constrained_surface = constrain_surface(self.surface_atoms)
-
-        # verify that the bulk and surface elements match:
-        assert set(bulk_object.bulk_atoms.symbols) == set(self.surface_atoms.symbols)
 
     def tile_atoms(self, atoms): # todo style wise: better to put inside or outside of class?
         '''

--- a/sample_structure.py
+++ b/sample_structure.py
@@ -41,8 +41,7 @@ class StructureSampler():
             self.logger.info(f'Enumerating all surfaces/configs for adsorbate {self.args.adsorbate_index} and bulks {self.bulk_indices_list}')
         else:
             self.logger.info('Sampling one random structure')
-
-        np.random.seed(self.args.seed)
+            np.random.seed(self.args.seed)
 
     def run(self):
         start = time.time()
@@ -62,13 +61,13 @@ class StructureSampler():
         '''
         self.all_bulks = []
         with open(self.args.bulk_db, 'rb') as f:
-            inv_index = pickle.load(f)
+            bulk_db_lookup = pickle.load(f)
 
         if self.args.enumerate_all_structures:
             for ind in self.bulk_indices_list:
-                self.all_bulks.append(Bulk(inv_index, self.args.precomputed_structures, ind))
+                self.all_bulks.append(Bulk(bulk_db_lookup, self.args.precomputed_structures, ind))
         else:
-            self.all_bulks.append(Bulk(inv_index, self.args.precomputed_structures))
+            self.all_bulks.append(Bulk(bulk_db_lookup, self.args.precomputed_structures))
 
     def load_and_write_surfaces(self):
         '''
@@ -146,7 +145,7 @@ def parse_args():
     # input and output
     parser.add_argument('--bulk_db', type=str, required=True, help='Underlying db for bulks')
     parser.add_argument('--adsorbate_db', type=str, required=True, help='Underlying db for adsorbates')
-    parser.add_argument('--output_dir', type=str, required=True, help='Output dir path')
+    parser.add_argument('--output_dir', type=str, required=True, help='Root directory for outputs')
 
     # for optimized (automatically try to use optimized if this is provided)
     parser.add_argument('--precomputed_structures', type=str, default=None, help='Root directory of precomputed structures')
@@ -154,9 +153,9 @@ def parse_args():
     # args for enumerating all combinations:
     parser.add_argument('--enumerate_all_structures', action='store_true', default=False,
         help='Find all possible structures given a specific adsorbate and a list of bulks')
-    parser.add_argument('--adsorbate_index', type=int, default=None, help='adsorbate index (int)')
+    parser.add_argument('--adsorbate_index', type=int, default=None, help='Adsorbate index (int)')
     parser.add_argument('--bulk_indices', type=str, default=None, help='Comma separated list of bulk indices')
-    parser.add_argument('--surface_index', type=int, default=None, help='optional surface index (int)')
+    parser.add_argument('--surface_index', type=int, default=None, help='Optional surface index (int)')
 
     parser.add_argument('--verbose', action='store_true', default=False, help='Log detailed info')
 

--- a/sample_structure.py
+++ b/sample_structure.py
@@ -13,18 +13,19 @@ import os
 import pickle
 import time
 
-
 class StructureSampler():
     '''
     Writes vasp input files for one of the following:
     - one adsorbate/bulk/surface/config, based on a random seed
     - one specified adsorbate, n specified bulks, and all possible surfaces and configs
+    - one specified adsorbate, n specified bulks, one specified surface, and all possible configs
 
-    The output directory structure will look like the following: for sampling a random structure,
-    the directories will be `random{seed}_surface` and `random{seed}_adslab` for the surface alone
-    and the adsorbate+surface, respectively. For enumerating all structures, the directories will be
-    `{adsorbate}_{bulk}_{surface}_surface` and `{adsorbate}_{bulk}_{surface}_adslab{config}`, where
-    everything in braces are the respective indices.
+    The output directory structure will look like the following:
+    - For sampling a random structure, the directories will be `random{seed}_surface` and
+        `random{seed}_adslab` for the surface alone and the adsorbate+surface, respectively.
+    - For enumerating all structures, the directories will be `{adsorbate}_{bulk}_{surface}_surface`
+        and `{adsorbate}_{bulk}_{surface}_adslab{config}`, where everything in braces are the
+        respective indices.
 
     '''
     def __init__(self, args):

--- a/sample_structure.py
+++ b/sample_structure.py
@@ -78,6 +78,7 @@ class StructureSampler():
             possible_surfaces = bulk.get_possible_surfaces()
             if self.args.enumerate_all_structures:
                 if self.args.surface_index is not None:
+                    assert 0 <= self.args.surface_index < len(possible_surfaces), 'Invalid surface index provided'
                     self.logger.info(f'Loading only surface {self.args.surface_index} for bulk {self.bulk_indices_list[bulk_ind]}')
                     included_surface_indices = [self.args.surface_index]
                 else:
@@ -93,6 +94,7 @@ class StructureSampler():
                 surface = Surface(bulk, possible_surfaces[surface_info_index], surface_info_index, len(possible_surfaces))
                 self.adsorbate = Adsorbate(self.args.adsorbate_db)
                 self.combine_and_write(surface)
+
 
     def combine_and_write(self, surface, cur_bulk_index=None, cur_surface_index=None):
         '''


### PR DESCRIPTION
* Move input file parsing out of sample_structures.py - this script will now only take adsorbate/bulk/surface indices. Any input file parsing (convert mpid/smiles to indices, read multiple lines) will be done by external scripts.
* Add option to specify one surface index instead of enumerating all surfaces
* Random sampling and choosing bulk by index now use different pkl files, to avoid indirect mpid-index mappings
* Add verifications that info from databases are consistent: the bulk db should be the appropriate structure, and the surface composition should match the bulk