### PR TITLE
Scripts to run sample_structure.py on slurm

### DIFF
--- a/gen_surface_indices.py
+++ b/gen_surface_indices.py
@@ -25,7 +25,7 @@ def parse_args():
     args = parser.parse_args()
     return args
 
-def get_possible_surfaces(bulk_ind, bulk_by_ind, precomputed_structures, mpid):
+def count_possible_surfaces(bulk_ind, bulk_by_ind, precomputed_structures, mpid):
     # given a bulk id (int), return the number of possible surfaces (int)
     # also verifies that the mpid is matching in bulk_db
     bulk = Bulk(bulk_by_ind, precomputed_structures, bulk_ind)
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     for structure_tuple in all_inputs:
         assert len(structure_tuple) == 2
         mpid, smiles = structure_tuple
-        num_surfaces = get_possible_surfaces(mpid_to_ind[mpid], bulk_by_ind, args.precomputed_structures, mpid)
+        num_surfaces = count_possible_surfaces(mpid_to_ind[mpid], bulk_by_ind, args.precomputed_structures, mpid)
         print(f'found {num_surfaces} possible surfaces for {mpid}, {smiles}')
         for ind in range(num_surfaces):
             all_outputs.append((mpid, smiles, ind))

--- a/gen_surface_indices.py
+++ b/gen_surface_indices.py
@@ -1,0 +1,56 @@
+import argparse
+import logging
+import pickle
+
+from ocdata.bulk_obj import Bulk
+from run_slurm import invert_mappings
+
+'''
+Given a file that's a pickled list of (bulk mpid, adsorbate smiles),
+generate a file that's a pickled list of (bulk mpid, adsorbate smiles, surface index)
+for all possible surfaces for that bulk.
+'''
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Sample adsorbate and bulk surface(s)')
+
+    parser.add_argument('--indices_file', type=str, required=True, help='Pickle containing tuples of (bulk, adsorbate) strings')
+    parser.add_argument('--output_file', type=str, required=True, help='Output filename for pickle of (bulk, adsorbate, surface index)')
+
+    parser.add_argument('--bulk_db', type=str, required=True, help='Underlying db for bulks')
+    parser.add_argument('--mpid_index_mapping', type=str, required=True, help='Text file that maps index to mpid')
+    parser.add_argument('--precomputed_structures', type=str, default=None, help='Root directory of precomputed structures')
+
+    # check that all needed args are supplied
+    args = parser.parse_args()
+    return args
+
+def get_possible_surfaces(bulk_ind, bulk_by_ind, precomputed_structures, mpid):
+    # given a bulk id (int), return the number of possible surfaces (int)
+    # also verifies that the mpid is matching in bulk_db
+    bulk = Bulk(bulk_by_ind, precomputed_structures, bulk_ind)
+    assert bulk.mpid == mpid, f'expected {mpid}, found {bulk.mpid}'
+    return(len(bulk.get_possible_surfaces()))
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    mpid_to_ind = invert_mappings(args.mpid_index_mapping, 3)
+
+    with open(args.indices_file, 'rb') as f:
+        all_inputs = pickle.load(f) # list of (mpid, smiles) tuples
+
+    all_outputs = [] # list of (mpid, smiles, surface index) tuples
+    with open(args.bulk_db, 'rb') as f:
+        bulk_by_ind = pickle.load(f)
+
+    for structure_tuple in all_inputs:
+        assert len(structure_tuple) == 2
+        mpid, smiles = structure_tuple
+        num_surfaces = get_possible_surfaces(mpid_to_ind[mpid], bulk_by_ind, args.precomputed_structures, mpid)
+        print(f'found {num_surfaces} possible surfaces for {mpid}, {smiles}')
+        for ind in range(num_surfaces):
+            all_outputs.append((mpid, smiles, ind))
+
+    with open(args.output_file, 'wb') as outf:
+        pickle.dump(all_outputs, outf)

--- a/gen_surface_indices.py
+++ b/gen_surface_indices.py
@@ -40,17 +40,28 @@ if __name__ == '__main__':
     with open(args.indices_file, 'rb') as f:
         all_inputs = pickle.load(f) # list of (mpid, smiles) tuples
 
+    print(f'found {len(all_inputs)} inputs')
+
     all_outputs = [] # list of (mpid, smiles, surface index) tuples
     with open(args.bulk_db, 'rb') as f:
         bulk_by_ind = pickle.load(f)
 
+    surfs_per_adbulk = {}
+    total_written = 0
     for structure_tuple in all_inputs:
         assert len(structure_tuple) == 2
         mpid, smiles = structure_tuple
-        num_surfaces = count_possible_surfaces(mpid_to_ind[mpid], bulk_by_ind, args.precomputed_structures, mpid)
-        print(f'found {num_surfaces} possible surfaces for {mpid}, {smiles}')
-        for ind in range(num_surfaces):
-            all_outputs.append((mpid, smiles, ind))
+
+        if (mpid, smiles) not in surfs_per_adbulk:
+            num_surfaces = count_possible_surfaces(mpid_to_ind[mpid], bulk_by_ind, args.precomputed_structures, mpid)
+            # print(f'found {num_surfaces} possible surfaces for {mpid}, {smiles}')
+            surfs_per_adbulk[(mpid, smiles)] = num_surfaces
+            total_written += num_surfaces
+            for ind in range(num_surfaces):
+                all_outputs.append((mpid, smiles, ind))
+
+    print(f'Found {len(surfs_per_adbulk)} unique (mpid, smiles) pairs')
+    print(f'Wrote {total_written} (mpid, smiles, surface_indx) sets')
 
     with open(args.output_file, 'wb') as outf:
         pickle.dump(all_outputs, outf)

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -158,7 +158,11 @@ class Combined():
             # Then, check the covalent radius between each adsorbate atoms
             # and its nearest neighbors that are slab atoms
             # to make sure adsorbate is not buried into the surface
-            nearneighbors = vnn.get_nn_info(structure, n=idx)
+            try:
+                nearneighbors = vnn.get_nn_info(structure, n=idx)
+            except ValueError:
+                return False
+
             slab_nn = [nn for nn in nearneighbors if nn['site_index'] not in adsorbate_indices]
             for nn in slab_nn:
                 ads_elem = structure[idx].species_string

--- a/run_slurm.py
+++ b/run_slurm.py
@@ -61,11 +61,12 @@ def main():
 
     if args.file_row_index is not None:
         all_structures = [all_structures[args.file_row_index]]
-        print(f'Only running line {args.file_row_index}')
+        print(f'Only running line {args.file_row_index} ({all_structures})')
 
     for structure_tuple in all_structures:
         mpid, smiles, surface_ind = structure_tuple
         run_sample_structure(args, smiles_to_ind[smiles], mpid_to_ind[mpid], surface_ind)
+        print(f'Done running line {args.file_row_index} ({all_structures})')
 
 if __name__ == '__main__':
     main()

--- a/run_slurm.py
+++ b/run_slurm.py
@@ -56,8 +56,6 @@ def main():
     with open(args.indices_file, 'rb') as f:
         all_structures = pickle.load(f)
 
-    # print(f'Found: {len(all_structures)} structures in file')
-
     if args.file_row_index is not None:
         all_structures = [all_structures[args.file_row_index]]
         print(f'Running line {args.file_row_index} ({all_structures})')

--- a/run_slurm.py
+++ b/run_slurm.py
@@ -1,0 +1,68 @@
+import argparse
+import logging
+import pickle
+
+from sample_structure import StructureSampler
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Sample adsorbate and bulk surface(s)')
+
+    parser.add_argument('--indices_file', type=str, required=True, help='Pickle containing tuples of (bulk mpid, adsorbate smiles, surface index)')
+    parser.add_argument('--file_row_index', type=int, default=None, help='Specify one row of the file to run')
+    parser.add_argument('--adsorbate_index_mapping', type=str, required=True, help='Text file that maps index to adsorbate')
+    parser.add_argument('--mpid_index_mapping', type=str, required=True, help='Text file that maps index to mpid')
+
+    ########## These args are used for sample_structure.py ##########
+    parser.add_argument('--bulk_db', type=str, required=True, help='Underlying db for bulks')
+    parser.add_argument('--adsorbate_db', type=str, required=True, help='Underlying db for adsorbates')
+    parser.add_argument('--output_dir', type=str, required=True, help='Root directory for outputs')
+    parser.add_argument('--precomputed_structures', type=str, default=None, help='Root directory of precomputed structures')
+    parser.add_argument('--verbose', action='store_true', default=False, help='Log detailed info')
+
+    args = parser.parse_args()
+    return args
+
+def invert_mappings(filename, expected_elems):
+    # takes a file that maps index to either mpid or smiles, and returns the inverse dict
+    # that maps mpid/smiles to bulk/adsorbate indices
+    # expected_elems is how many space-separated items you expect to see each line
+    str_to_ind = {}
+    with open(filename, 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            elems = line.strip().split(' ')
+            assert len(elems) == expected_elems
+            str_to_ind[elems[1]] = int(elems[0])
+    return str_to_ind
+
+def run_sample_structure(args, adsorbate, bulk, surface):
+    print(f'Running sample_structure.py for adsorbate {adsorbate}, bulk {bulk}, surface {surface}')
+
+    # manually set some args
+    args.enumerate_all_structures = True
+    args.adsorbate_index = adsorbate
+    args.bulk_indices = str(bulk)
+    args.surface_index = surface
+
+    job = StructureSampler(args)
+    job.run()
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    # get mappings from string -> int
+    smiles_to_ind = invert_mappings(args.adsorbate_index_mapping, 2)
+    mpid_to_ind = invert_mappings(args.mpid_index_mapping, 3)
+
+    with open(args.indices_file, 'rb') as f:
+        all_structures = pickle.load(f)
+
+    print(f'Found: {len(all_structures)} structures in file')
+
+    if args.file_row_index is not None:
+        all_structures = [all_structures[args.file_row_index]]
+        printf(f'Only running line {args.file_row_index}')
+
+    for structure_tuple in all_structures:
+        mpid, smiles, surface_ind = structure_tuple
+        run_sample_structure(args, smiles_to_ind[smiles], mpid_to_ind[mpid], surface_ind)

--- a/run_slurm.py
+++ b/run_slurm.py
@@ -36,8 +36,6 @@ def invert_mappings(filename, expected_elems):
     return str_to_ind
 
 def run_sample_structure(args, adsorbate, bulk, surface):
-    print(f'Running sample_structure.py for adsorbate {adsorbate}, bulk {bulk}, surface {surface}')
-
     # manually set some args
     args.enumerate_all_structures = True
     args.adsorbate_index = adsorbate
@@ -46,6 +44,7 @@ def run_sample_structure(args, adsorbate, bulk, surface):
 
     job = StructureSampler(args)
     job.run()
+    print(f'Done running sample_structure.py for {adsorbate}_{bulk}_{surface}')
 
 def main():
     args = parse_args()
@@ -57,16 +56,15 @@ def main():
     with open(args.indices_file, 'rb') as f:
         all_structures = pickle.load(f)
 
-    print(f'Found: {len(all_structures)} structures in file')
+    # print(f'Found: {len(all_structures)} structures in file')
 
     if args.file_row_index is not None:
         all_structures = [all_structures[args.file_row_index]]
-        print(f'Only running line {args.file_row_index} ({all_structures})')
+        print(f'Running line {args.file_row_index} ({all_structures})')
 
     for structure_tuple in all_structures:
         mpid, smiles, surface_ind = structure_tuple
         run_sample_structure(args, smiles_to_ind[smiles], mpid_to_ind[mpid], surface_ind)
-        print(f'Done running line {args.file_row_index} ({all_structures})')
 
 if __name__ == '__main__':
     main()

--- a/run_slurm.py
+++ b/run_slurm.py
@@ -47,7 +47,7 @@ def run_sample_structure(args, adsorbate, bulk, surface):
     job = StructureSampler(args)
     job.run()
 
-if __name__ == '__main__':
+def main():
     args = parse_args()
 
     # get mappings from string -> int
@@ -61,8 +61,11 @@ if __name__ == '__main__':
 
     if args.file_row_index is not None:
         all_structures = [all_structures[args.file_row_index]]
-        printf(f'Only running line {args.file_row_index}')
+        print(f'Only running line {args.file_row_index}')
 
     for structure_tuple in all_structures:
         mpid, smiles, surface_ind = structure_tuple
         run_sample_structure(args, smiles_to_ind[smiles], mpid_to_ind[mpid], surface_ind)
+
+if __name__ == '__main__':
+    main()

--- a/sample_structure.py
+++ b/sample_structure.py
@@ -21,10 +21,10 @@ class StructureSampler():
     - one specified adsorbate, n specified bulks, one specified surface, and all possible configs
 
     The output directory structure will look like the following:
-    - For sampling a random structure, the directories will be `random{seed}_surface` and
-        `random{seed}_adslab` for the surface alone and the adsorbate+surface, respectively.
-    - For enumerating all structures, the directories will be `{adsorbate}_{bulk}_{surface}_surface`
-        and `{adsorbate}_{bulk}_{surface}_adslab{config}`, where everything in braces are the
+    - For sampling a random structure, the directories will be `random{seed}/surface` and
+        `random{seed}/adslab` for the surface alone and the adsorbate+surface, respectively.
+    - For enumerating all structures, the directories will be `{adsorbate}_{bulk}_{surface}/surface`
+        and `{adsorbate}_{bulk}_{surface}/adslab{config}`, where everything in braces are the
         respective indices.
 
     '''
@@ -53,7 +53,7 @@ class StructureSampler():
         self.load_and_write_surfaces()
 
         end = time.time()
-        print(f'Done! ({round(end - start, 2)}s)')
+        self.logger.info(f'Done! ({round(end - start, 2)}s)')
 
     def load_bulks(self):
         '''
@@ -115,7 +115,7 @@ class StructureSampler():
     def write_surface(self, surface, output_name_template):
         # write files for just the surface
         bulk_dict = surface.get_bulk_dict()
-        bulk_dir = os.path.join(self.args.output_dir, output_name_template + '_surface')
+        bulk_dir = os.path.join(self.args.output_dir, output_name_template, 'surface')
         write_vasp_input_files(bulk_dict['bulk_atomsobject'], bulk_dir)
         self.write_metadata_pkl(bulk_dict, os.path.join(bulk_dir, 'metadata.pkl'))
         self.logger.info(f"wrote surface ({bulk_dict['bulk_samplingstr']}) to {bulk_dir}")
@@ -125,9 +125,9 @@ class StructureSampler():
         self.logger.info(f'Writing {combined.num_configs} adslab configs')
         for config_ind in range(combined.num_configs):
             if self.args.enumerate_all_structures:
-                adsorbed_bulk_dir = os.path.join(self.args.output_dir, output_name_template + f'_adslab{config_ind}')
+                adsorbed_bulk_dir = os.path.join(self.args.output_dir, output_name_template, f'adslab{config_ind}')
             else:
-                adsorbed_bulk_dir = os.path.join(self.args.output_dir, output_name_template + '_adslab')
+                adsorbed_bulk_dir = os.path.join(self.args.output_dir, output_name_template, 'adslab')
             adsorbed_bulk_dict = combined.get_adsorbed_bulk_dict(config_ind)
             write_vasp_input_files(adsorbed_bulk_dict['adsorbed_bulk_atomsobject'], adsorbed_bulk_dir)
             self.write_metadata_pkl(adsorbed_bulk_dict, os.path.join(adsorbed_bulk_dir, 'metadata.pkl'))


### PR DESCRIPTION
Adds two scripts:
* `gen_surface_indices.py` takes in a given list of (bulk mpid, adsorbate smiles) tuples and generates a list of tuples of (bulk mpid, adsorbate smiles, surface index) for all possible surfaces
* `run_slurm.py` takes in the list of (bulk mpid, adsorbate smiles, surface index) tuples, along with an optional arg of which specific line in the list to read, and calls `StructureSampler` from `sample_structure.py` with the appropriate args for the specific bulk+adsorbate+surface.