### PR TITLE
[Backward incompatible change] Modify metadata string

### DIFF
--- a/ocdata/adsorbates.py
+++ b/ocdata/adsorbates.py
@@ -1,7 +1,7 @@
 
 import numpy as np
 import pickle
-
+import os
 
 class Adsorbate():
     '''
@@ -36,7 +36,8 @@ class Adsorbate():
             smiles                   SMILES-formatted representation of the adsorbate
             bond_indices             list of integers indicating the indices of the atoms in
                                      the adsorbate that are meant to be bonded to the surface
-            adsorbate_sampling_str   Enum string specifying the sample, [index]/[total]
+            adsorbate_sampling_str   Enum string specifying the sample, [index]
+            adsorbate_db_fname       filename denoting which version was used to sample
         '''
         with open(adsorbate_database, 'rb') as f:
             inv_index = pickle.load(f)
@@ -46,5 +47,6 @@ class Adsorbate():
         else:
             element = np.random.choice(len(inv_index))
 
-        self.adsorbate_sampling_str = str(element) + "/" + str(len(inv_index))
+        self.adsorbate_sampling_str = str(element) 
         self.atoms, self.smiles, self.bond_indices = inv_index[element]
+        self.adsorbate_db_fname = os.path.basename(adsorbate_database)

--- a/ocdata/bulk_obj.py
+++ b/ocdata/bulk_obj.py
@@ -76,8 +76,9 @@ class Bulk():
                 assert isinstance(bulk_db[bulk_index], tuple)
 
                 self.bulk_atoms, self.mpid, self.bulk_sampling_str, self.index_of_bulk_atoms = bulk_db[bulk_index]
+                self.bulk_sampling_str = f'{self.index_of_bulk_atoms}'
                 self.n_elems = len(set(self.bulk_atoms.symbols)) # 1, 2, or 3
-                self.elem_sampling_str = f'{self.n_elems}/{max_elems}'
+                self.elem_sampling_str = f'{self.n_elems}' 
 
             else:
                 self.sample_n_elems()

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -252,4 +252,5 @@ class Combined():
                                                self.surface.top,
                                                self.adsorbate.smiles,
                                                self.all_sites[ind]),
-                "adsorbed_bulk_samplingstr" : self.surface.overall_sampling_str + "_" + ads_sampling_str}
+                "adsorbed_bulk_samplingstr" : self.surface.overall_sampling_str + "_" + ads_sampling_str,
+                "adsorbed_db_version": self.adsorbate.adsorbate_db_fname}


### PR DESCRIPTION
This PR modifies the way we store metadata string for both surface and adsorbates. 

We additionally now store adsorbate db filename. 

We can't store bulk db filename, as we use precomputed paths. 