### PR TITLE
Bugfixes in the random placement code

### DIFF
--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -452,6 +452,7 @@ class CombinedRandomly:
                 triangle_positions, equal_distr, self.added_z
             )
             all_sites += sites
+        np.random.shuffle(all_sites)
         return all_sites[:num_sites]
 
     def _random_sites_on_triangle(self, surfsite_pos, k, added_z):

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -507,7 +507,7 @@ class CombinedRandomly:
             if self.rotate_adsorbate:
                 adsorbate_idx = [idx for idx, tag in enumerate(final_tags) if tag == 2]
                 struct = AseAtomsAdaptor.get_structure(adslab)
-                rotation = np.random.choice(np.arange(0, 360, 10))
+                rotation = np.random.uniform(0, 2 * np.pi)
                 struct.rotate_sites(adsorbate_idx, rotation, (0, 0, 1), site)
                 adslab = AseAtomsAdaptor.get_atoms(struct)
                 adslab.set_tags(final_tags)

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -444,7 +444,7 @@ class CombinedRandomly:
         """
         dt = scipy.spatial.Delaunay(surface_atoms_pos[:, :2])
         simplices = dt.simplices
-        equal_distr = max(1, int(num_sites / len(simplices)))
+        equal_distr = int(np.ceil(num_sites / len(simplices)))
         all_sites = []
         for tri in simplices:
             triangle_positions = surface_atoms_pos[tri]

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -444,7 +444,7 @@ class CombinedRandomly:
         """
         dt = scipy.spatial.Delaunay(surface_atoms_pos[:, :2])
         simplices = dt.simplices
-        equal_distr = int(num_sites / len(simplices))
+        equal_distr = max(1, int(num_sites / len(simplices)))
         all_sites = []
         for tri in simplices:
             triangle_positions = surface_atoms_pos[tri]
@@ -452,7 +452,7 @@ class CombinedRandomly:
                 triangle_positions, equal_distr, self.added_z
             )
             all_sites += sites
-        return all_sites
+        return all_sites[:num_sites]
 
     def _random_sites_on_triangle(self, surfsite_pos, k, added_z):
         """


### PR DESCRIPTION
This PR fixes the following bugs in the random placement code:
- For the case where `len(simplices)` (from Delauney triangulation) is larger than `num_sites`, 0 sites were getting sampled.
- For the random rotation of the adsorbate along the z axis, the angle being sampled was in degrees whereas [pymatgen expects it in radians](https://github.com/materialsproject/pymatgen/blob/master/pymatgen/core/structure.py#L3844).