### PR TITLE
random placement bugfix: place binding adsorbate onto site

### DIFF
--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -608,6 +608,12 @@ class CombinedRandomly:
         implements those fixes directly.
 
         https://gitlab.com/ase/ase/-/commit/e60e804eff0a82a5c13a56297321953983a06cf3
+
+        Args:
+            atoms: ASE atoms object.
+            com: Center of mass to transform provided atoms object to, tuple.
+        Returns:
+            Atoms object transformed to the COM provided.
         """
         old_com = atoms.get_center_of_mass()
         difference = com - old_com

--- a/ocdata/combined.py
+++ b/ocdata/combined.py
@@ -499,6 +499,8 @@ class CombinedRandomly:
             # Add adsorbate to a site
             adsorbate_c = adsorbate.copy()
             surface_c = surface.copy()
+            # Set adsorbate center of mass to (0,0,0)
+            adsorbate_c = self.set_center_of_mass(adsorbate_c, (0, 0, 0))
             adsorbate_c.translate(site)
             adslab = surface_c + adsorbate_c
             tags = [2] * len(adsorbate)
@@ -587,3 +589,16 @@ class CombinedRandomly:
             + "_"
             + ads_sampling_str,
         }
+
+    def set_center_of_mass(self, atoms, com):
+        """
+        ASE's public releases have a bug in setting the center of mass. This
+        implements those fixes directly.
+
+        https://gitlab.com/ase/ase/-/commit/e60e804eff0a82a5c13a56297321953983a06cf3
+        """
+        old_com = atoms.get_center_of_mass()
+        difference = com - old_com
+
+        atoms.set_positions(atoms.get_positions() + difference)
+        return atoms


### PR DESCRIPTION
Random placement code had previously loaded an adsorbate and naively translated it onto the site. This only works if the adsorbate is located at (0,0,0) to begin with. This PR updates this logic to correctly translate the adsorbate onto the site. For single atom adsorbates (*H, *C, etc.) this is straightforward. However, for multi atom adsorbate (*CO, *CHO, etc.) we need a convention to what gets placed onto the site. Two methods described:

1.  Center of mass. Set the adsorbate center of mass to be (0,0,0) and then translate onto the site
2. Binding adsorbate. Most adsorbates we have intuition as to what atom actually binds to the surface (i.e. C, O, etc.). We can place this adsorbate on that site.

This PR incorporates (2). This PR doesn't support bidentate placement, instead, a single binding atom is randomly selected from the provided bond indices. A future PR will update this accordingly.

NOTE: Consistent with what was done previously, this PR still loads the initial atoms configuration and does not modify the orientation before placement. Meaning that if the binding atom is furthest from the surface, translation could push atoms closer to the surface. However, a cushion of 2A exists to avoid possible concerns of atoms going into the surface. A future PR will incorporate a full random sampling of configuration space across x,y,z, not just the z-axis as originally proposed here.

Test across multiple adsorbates and systems - 

Before:
```
['H']
desired site [ 5.43808445  8.46010604 23.03441043]
loaded atoms [[0.5 0.5 0.5]]
after placement [[ 5.93808445  8.96010604 23.53441043]]

['C', 'O']
desired site [ 3.80329225  5.12027289 20.48227425]
loaded atoms [[ 0.5     0.5    -0.0831]
 [ 0.5     0.5     1.0831]]
after placement [[ 4.30329225  5.62027289 20.39917425]
 [ 4.30329225  5.62027289 21.56537425]]

['C', 'H', 'O']
desired site [ 2.49161953  0.13363985 24.10688804]
loaded atoms [[ 0.52125  0.5039   0.1858 ]
 [ 1.36225  1.0316   0.717  ]
 [-0.36225 -0.0316   0.8142 ]]
after placement [[ 3.01286953  0.63753985 24.29268804]
 [ 3.85386953  1.16523985 24.82388804]
 [ 2.12936953  0.10203985 24.92108804]]

['C', 'C', 'O', 'O', 'H']
desired site [ 3.41717898  0.72541998 19.27153949]
loaded atoms [[ 2.37761043e-16  2.06980072e+00  0.00000000e+00]
 [ 0.00000000e+00  3.58600000e+00  6.00000000e-02]
 [ 8.71593596e-17  8.40044642e-01  7.10000000e-01]
 [ 0.00000000e+00  4.81600000e+00  7.70000000e-01]
 [-1.57164386e-17  4.44089210e-16  1.19500000e+00]]
after placement [[ 3.41717898  2.7952207  19.27153949]
 [ 3.41717898  4.31141998 19.33153949]
 [ 3.41717898  1.56546463 19.98153949]
 [ 3.41717898  5.54141998 20.04153949]
 [ 3.41717898  0.72541998 20.46653949]]

['C']
desired site [ 5.97345897 12.61462659 20.62304702]
loaded atoms [[0.5 0.5 0.5]]
after placement [[ 6.47345897 13.11462659 21.12304702]]
```

This PR:
```
['H']
desired site [ 5.43808445  8.46010604 23.03441043]
loaded atoms [[0.5 0.5 0.5]]
after placement [[ 5.43808445  8.46010604 23.03441043]]

['C', 'O']
desired site [ 3.80329225  5.12027289 20.48227425]
loaded atoms [[ 0.5     0.5    -0.0831]
 [ 0.5     0.5     1.0831]]
after placement [[ 3.80329225  5.12027289 20.48227425]
 [ 3.80329225  5.12027289 21.64847425]]

['C', 'H', 'O']
desired site [ 2.49161953  0.13363985 24.10688804]
loaded atoms [[ 0.52125  0.5039   0.1858 ]
 [ 1.36225  1.0316   0.717  ]
 [-0.36225 -0.0316   0.8142 ]]
after placement [[ 2.49161953  0.13363985 24.10688804]
 [ 3.33261953  0.66133985 24.63808804]
 [ 1.60811953 -0.40186015 24.73528804]]

['C', 'C', 'O', 'O', 'H']
desired site [ 3.41717898  0.72541998 19.27153949]
loaded atoms [[ 2.37761043e-16  2.06980072e+00  0.00000000e+00]
 [ 0.00000000e+00  3.58600000e+00  6.00000000e-02]
 [ 8.71593596e-17  8.40044642e-01  7.10000000e-01]
 [ 0.00000000e+00  4.81600000e+00  7.70000000e-01]
 [-1.57164386e-17  4.44089210e-16  1.19500000e+00]]
after placement [[ 3.41717898  0.72541998 19.27153949]
 [ 3.41717898  2.24161927 19.33153949]
 [ 3.41717898 -0.50433609 19.98153949]
 [ 3.41717898  3.47161927 20.04153949]
 [ 3.41717898 -1.34438073 20.46653949]]


['C']
desired site [ 5.97345897 12.61462659 20.62304702]
loaded atoms [[0.5 0.5 0.5]]
after placement [[ 5.97345897 12.61462659 20.62304702]]
```