### PR TITLE
inplace bugfix

### DIFF
--- a/ocdata/vasp.py
+++ b/ocdata/vasp.py
@@ -179,7 +179,7 @@ def write_vasp_input_files(atoms, outdir='.', vasp_flags=None):
     if vasp_flags is None:  # Immutable default
         vasp_flags = VASP_FLAGS.copy()
 
-    atoms, vasp_flags = _clean_up_inputs(atoms, vasp_flags)
+    atoms, vasp_flags = _clean_up_inputs(atoms, vasp_flags.copy())
     calc = Vasp(directory=outdir, **vasp_flags)
     calc.write_input(atoms)
 


### PR DESCRIPTION
If VASP flags is fed in as an input (which it is for the majority of our applications), this modifies the flag inplace. This is problematic since kpoints are calculated based on whether they are found in the flags. For a use case like:


```
VASP_FLAGS = {..}
for atoms in list_of_atoms_objects_to_write_inputs:
      write_vasp_input_files(atoms, output_path, VASP_FLAGS)
```

The very first atoms object will have KPOINTS correctly computed, but all subsequent atoms will be using the KPOINTS of the first one...