### PR TITLE
log successful completion

### DIFF
--- a/ocdata/structure_generator.py
+++ b/ocdata/structure_generator.py
@@ -405,6 +405,8 @@ if __name__ == "__main__":
             tqdm(pool.imap(run_placements, pool_inputs), total=len(pool_inputs))
         )
         pool.close()
+
+        print("Placements successfully generated!")
     elif args.bulk_indices_file:
         with open(args.bulk_indices_file, "r") as f:
             all_indices = f.read().splitlines()
@@ -417,6 +419,8 @@ if __name__ == "__main__":
             tqdm(pool.imap(precompute_slabs, inds_to_run), total=len(inds_to_run))
         )
         pool.close()
+
+        print("Slabs successfully precomputed!")
     else:
         job = StructureGenerator(
             args,
@@ -425,3 +429,5 @@ if __name__ == "__main__":
             adsorbate_index=args.adsorbate_index,
         )
         job.run()
+
+        print("Placements successfully generated!")


### PR DESCRIPTION
When parallelizing the driver script, providing a stdout when successful completion to better parse errors when running across multiple nodes.