### PR TITLE
add no vasp flag to precompute slabs

### DIFF
--- a/ocdata/structure_generator.py
+++ b/ocdata/structure_generator.py
@@ -355,8 +355,9 @@ def precompute_slabs(bulk_ind):
             max_miller=args.max_miller,
             precomputed_slabs_dir=args.precomputed_slabs_dir,
         )
-        for surf_idx, slab in enumerate(all_slabs):
-            write_surface(args, slab, bulk_ind, surf_idx)
+        if not args.no_vasp:
+            for surf_idx, slab in enumerate(all_slabs):
+                write_surface(args, slab, bulk_ind, surf_idx)
     except Exception:
         traceback.print_exc()
 


### PR DESCRIPTION
We may not always want to write VASP inputs when precomputing surfaces. Introduce that flexibility here with the `--no_vasp` flag used throughout this script.