### PR TITLE
Allow pre-loaded databases in initializers

### DIFF
--- a/ocdata/core/adsorbate.py
+++ b/ocdata/core/adsorbate.py
@@ -1,4 +1,5 @@
 import pickle
+from typing import Any, Dict, Tuple
 import warnings
 
 import ase
@@ -36,6 +37,7 @@ class Adsorbate:
         adsorbate_id_from_db: int = None,
         adsorbate_smiles_from_db: str = None,
         adsorbate_db_path: str = ADSORBATES_PKL_PATH,
+        adsorbate_db: Dict[int, Tuple[Any, ...]] = None,
         adsorbate_binding_indices: list = None,
     ):
         self.adsorbate_id_from_db = adsorbate_id_from_db
@@ -61,7 +63,7 @@ class Adsorbate:
             else:
                 self.binding_indices = adsorbate_binding_indices
         elif adsorbate_id_from_db is not None:
-            adsorbate_db = pickle.load(open(adsorbate_db_path, "rb"))
+            adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
             (
                 self.atoms,
                 self.smiles,
@@ -69,7 +71,7 @@ class Adsorbate:
                 self.reaction_string,
             ) = adsorbate_db[adsorbate_id_from_db]
         elif adsorbate_smiles_from_db is not None:
-            adsorbate_db = pickle.load(open(adsorbate_db_path, "rb"))
+            adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
             adsorbate_obj_tuple = [
                 (idx, adsorbate_info)
                 for idx, adsorbate_info in adsorbate_db.items()
@@ -89,7 +91,7 @@ class Adsorbate:
                 ) = adsorbate_obj_tuple[0][1]
                 self.adsorbate_id_from_db = adsorbate_obj_tuple[0][0]
         else:
-            adsorbate_db = pickle.load(open(adsorbate_db_path, "rb"))
+            adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
             self._get_adsorbate_from_random(adsorbate_db)
 
     def __len__(self):

--- a/ocdata/core/bulk.py
+++ b/ocdata/core/bulk.py
@@ -1,5 +1,6 @@
 import os
 import pickle
+from typing import Any, Dict, List
 import warnings
 
 import ase
@@ -27,8 +28,8 @@ class Bulk:
         Src id of bulk to select (e.g. "mp-30").
     bulk_db_path: str
         Path to bulk database.
-    precomputed_slabs_path: str
-        Path to folder of precomputed slabs.
+    bulk_db: List[Dict[str, Any]]
+        Already-loaded database.
     """
 
     def __init__(
@@ -37,6 +38,7 @@ class Bulk:
         bulk_id_from_db: int = None,
         bulk_src_id_from_db: str = None,
         bulk_db_path: str = BULK_PKL_PATH,
+        bulk_db: List[Dict[str, Any]] = None,
     ):
         self.bulk_id_from_db = bulk_id_from_db
         self.bulk_db_path = bulk_db_path
@@ -45,11 +47,11 @@ class Bulk:
             self.atoms = bulk_atoms.copy()
             self.src_id = None
         elif bulk_id_from_db is not None:
-            bulk_db = pickle.load(open(bulk_db_path, "rb"))
+            bulk_db = bulk_db or pickle.load(open(bulk_db_path, "rb"))
             bulk_obj = bulk_db[bulk_id_from_db]
             self.atoms, self.src_id = bulk_obj["atoms"], bulk_obj["src_id"]
         elif bulk_src_id_from_db is not None:
-            bulk_db = pickle.load(open(bulk_db_path, "rb"))
+            bulk_db = bulk_db or pickle.load(open(bulk_db_path, "rb"))
             bulk_obj_tuple = [
                 (idx, bulk)
                 for idx, bulk in enumerate(bulk_db)
@@ -65,7 +67,7 @@ class Bulk:
                 self.bulk_id_from_db = bulk_obj_tuple[0][0]
                 self.atoms, self.src_id = bulk_obj["atoms"], bulk_obj["src_id"]
         else:
-            bulk_db = pickle.load(open(bulk_db_path, "rb"))
+            bulk_db = bulk_db or pickle.load(open(bulk_db_path, "rb"))
             self._get_bulk_from_random(bulk_db)
 
     def _get_bulk_from_random(self, bulk_db):

--- a/tests/test_adsorbate.py
+++ b/tests/test_adsorbate.py
@@ -1,8 +1,15 @@
 import random
 
+import ase
 import numpy as np
 
 from ocdata.core import Adsorbate
+
+
+_test_db = {
+    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0])),
+    1: (ase.Atoms(symbols="C", pbc="False"), "*C", np.array([0])),
+}
 
 
 class TestAdsorbate:
@@ -24,3 +31,18 @@ class TestAdsorbate:
         adsorbate = Adsorbate()
         assert adsorbate.atoms.get_chemical_formula() == "C2H3O"
         assert adsorbate.smiles == "*COHCH2"
+
+    def test_adsorbate_init_from_id_with_db(self):
+        adsorbate = Adsorbate(adsorbate_id_from_db=1, adsorbate_db=_test_db)
+        assert adsorbate.atoms.get_chemical_formula() == "C"
+
+    def test_adsorbate_init_from_smiles_with_db(self):
+        adsorbate = Adsorbate(adsorbate_smiles_from_db="*C", adsorbate_db=_test_db)
+        assert adsorbate.atoms.get_chemical_formula() == "C"
+
+    def test_adsorbate_init_random_with_db(self):
+        random.seed(1)
+        np.random.seed(1)
+
+        adsorbate = Adsorbate(adsorbate_db=_test_db)
+        assert adsorbate.atoms.get_chemical_formula() == "C"

--- a/tests/test_adsorbate.py
+++ b/tests/test_adsorbate.py
@@ -7,8 +7,8 @@ from ocdata.core import Adsorbate
 
 
 _test_db = {
-    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0])),
-    1: (ase.Atoms(symbols="C", pbc="False"), "*C", np.array([0])),
+    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0]), ""),
+    1: (ase.Atoms(symbols="C", pbc="False"), "*C", np.array([0]), ""),
 }
 
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -2,6 +2,7 @@ import os
 import pickle
 import random
 
+import ase
 import numpy as np
 import pytest
 
@@ -15,6 +16,20 @@ def load_bulk(request):
 
     request.cls.precomputed_path = os.path.join(cwd, str(request.cls.idx) + ".pkl")
     request.cls.bulk = Bulk(bulk_id_from_db=request.cls.idx)
+
+
+_test_db = [
+    {
+        "atoms": ase.Atoms(symbols="H", pbc=False),
+        "src_id": "test_id_1",
+        "bulk_sampling_str": "test_1",
+    },
+    {
+        "atoms": ase.Atoms(symbols="C", pbc=False),
+        "src_id": "test_id_2",
+        "bulk_sampling_str": "test_2",
+    },
+]
 
 
 @pytest.mark.usefixtures("load_bulk")
@@ -35,6 +50,21 @@ class TestBulk:
 
         bulk = Bulk()
         assert bulk.atoms.get_chemical_formula() == "IrSn2"
+
+    def test_bulk_init_from_id_with_db(self):
+        bulk = Bulk(bulk_id_from_db=1, bulk_db=_test_db)
+        assert bulk.atoms.get_chemical_formula() == "C"
+
+    def test_bulk_init_from_src_id_with_db(self):
+        bulk = Bulk(bulk_src_id_from_db="test_id_2", bulk_db=_test_db)
+        assert bulk.atoms.get_chemical_formula() == "C"
+
+    def test_bulk_init_random_with_db(self):
+        random.seed(1)
+        np.random.seed(1)
+
+        bulk = Bulk(bulk_db=_test_db)
+        assert bulk.atoms.get_chemical_formula() == "C"
 
     def test_unique_slab_enumeration(self):
         slabs = self.bulk.get_slabs()


### PR DESCRIPTION
Bulk and Adsorbate initializers accept a path to a database stored in a pkl file. This adds an option to pass in an already-loaded database. The goal is to support cases where databases are being read outside of these classes.