### PR TITLE
Backwards compatibility for adsorbate db

### DIFF
--- a/ocdata/core/adsorbate.py
+++ b/ocdata/core/adsorbate.py
@@ -64,12 +64,7 @@ class Adsorbate:
                 self.binding_indices = adsorbate_binding_indices
         elif adsorbate_id_from_db is not None:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
-            (
-                self.atoms,
-                self.smiles,
-                self.binding_indices,
-                self.reaction_string,
-            ) = adsorbate_db[adsorbate_id_from_db]
+            self._save_adsorbate(adsorbate_db[adsorbate_id_from_db])
         elif adsorbate_smiles_from_db is not None:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
             adsorbate_obj_tuple = [
@@ -83,12 +78,7 @@ class Adsorbate:
                 )
                 self._get_adsorbate_from_random(adsorbate_db)
             else:
-                (
-                    self.atoms,
-                    self.smiles,
-                    self.binding_indices,
-                    self.reaction_string,
-                ) = adsorbate_obj_tuple[0][1]
+                self._save_adsorbate(adsorbate_obj_tuple[0][1])
                 self.adsorbate_id_from_db = adsorbate_obj_tuple[0][0]
         else:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
@@ -108,12 +98,19 @@ class Adsorbate:
 
     def _get_adsorbate_from_random(self, adsorbate_db):
         self.adsorbate_id_from_db = np.random.randint(len(adsorbate_db))
-        (
-            self.atoms,
-            self.smiles,
-            self.binding_indices,
-            self.reaction_string,
-        ) = adsorbate_db[self.adsorbate_id_from_db]
+        self._save_adsorbate(adsorbate_db[self.adsorbate_id_from_db])
+
+    def _save_adsorbate(self, adsorbate: Tuple[Any, ...]) -> None:
+        """
+        Saves the fields from an adsorbate stored in a database. Fields added
+        after the first revision are conditionally added for backwards
+        compatibility with older database files.
+        """
+        self.atoms = adsorbate[0]
+        self.smiles = adsorbate[1]
+        self.binding_indices = adsorbate[2]
+        if len(adsorbate) > 3:
+            self.reaction_string = adsorbate[3]
 
 
 def randomly_rotate_adsorbate(

--- a/ocdata/core/adsorbate.py
+++ b/ocdata/core/adsorbate.py
@@ -64,7 +64,7 @@ class Adsorbate:
                 self.binding_indices = adsorbate_binding_indices
         elif adsorbate_id_from_db is not None:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
-            self._save_adsorbate(adsorbate_db[adsorbate_id_from_db])
+            self._load_adsorbate(adsorbate_db[adsorbate_id_from_db])
         elif adsorbate_smiles_from_db is not None:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
             adsorbate_obj_tuple = [
@@ -78,7 +78,7 @@ class Adsorbate:
                 )
                 self._get_adsorbate_from_random(adsorbate_db)
             else:
-                self._save_adsorbate(adsorbate_obj_tuple[0][1])
+                self._load_adsorbate(adsorbate_obj_tuple[0][1])
                 self.adsorbate_id_from_db = adsorbate_obj_tuple[0][0]
         else:
             adsorbate_db = adsorbate_db or pickle.load(open(adsorbate_db_path, "rb"))
@@ -98,9 +98,9 @@ class Adsorbate:
 
     def _get_adsorbate_from_random(self, adsorbate_db):
         self.adsorbate_id_from_db = np.random.randint(len(adsorbate_db))
-        self._save_adsorbate(adsorbate_db[self.adsorbate_id_from_db])
+        self._load_adsorbate(adsorbate_db[self.adsorbate_id_from_db])
 
-    def _save_adsorbate(self, adsorbate: Tuple[Any, ...]) -> None:
+    def _load_adsorbate(self, adsorbate: Tuple[Any, ...]) -> None:
         """
         Saves the fields from an adsorbate stored in a database. Fields added
         after the first revision are conditionally added for backwards

--- a/tests/test_adsorbate.py
+++ b/tests/test_adsorbate.py
@@ -7,8 +7,13 @@ from ocdata.core import Adsorbate
 
 
 _test_db = {
-    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0]), ""),
-    1: (ase.Atoms(symbols="C", pbc="False"), "*C", np.array([0]), ""),
+    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0]), "rxn_1"),
+    1: (ase.Atoms(symbols="C", pbc="False"), "*C", np.array([0]), "rxn_2"),
+}
+
+# Used to test backwards compatability with old database formats
+_test_db_old = {
+    0: (ase.Atoms(symbols="H", pbc="False"), "*H", np.array([0])),
 }
 
 
@@ -46,3 +51,11 @@ class TestAdsorbate:
 
         adsorbate = Adsorbate(adsorbate_db=_test_db)
         assert adsorbate.atoms.get_chemical_formula() == "C"
+
+    def test_adsorbate_init_reaction_string(self):
+        adsorbate = Adsorbate(adsorbate_id_from_db=0, adsorbate_db=_test_db)
+        assert adsorbate.reaction_string == "rxn_1"
+
+    def test_adsorbate_init_reaction_string_with_old_db(self):
+        adsorbate = Adsorbate(adsorbate_id_from_db=0, adsorbate_db=_test_db_old)
+        assert not hasattr(adsorbate, "reaction_string")


### PR DESCRIPTION
https://github.com/Open-Catalyst-Project/Open-Catalyst-Dataset/pull/67 added support for reaction strings in adsorbate database entries. Tuple unpacking in the Adsorbate initializer assumes length 4 (after the reaction string was added). Older databases will be missing the reaction string and the initializer will raise when they are used. This makes the initializer backwards compatible with older databases, saving the reaction string only if present.