### PR TITLE
skip vasp surface inputs + Pymatgen install fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,6 @@ commands:
               # Conda configuration
               conda config --set always_yes yes --set auto_update_conda false
               # Update conda
-              conda update conda
               conda create -n ocp python=3.9
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              pip install ase==3.22.1 black==22.3.0 pymatgen==2023.1.20
+              pip install ase==3.22.1 black==22.3.0 pymatgen==2023.5.10
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,8 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              pip install pymatgen==2023.1.30 ase==3.22.1 black==22.3.0
+              conda install -c conda-forge pymatgen=2023.1.20
+              pip install ase==3.22.1 black==22.3.0
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              pip install pymatgen==2023.5.10 ase==3.22.1 black==22.3.0
+              pip install pymatgen==2023.1.30 ase==3.22.1 black==22.3.0
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              conda install -c conda-forge pymatgen=2023.1.20
-              pip install ase==3.22.1 black==22.3.0
+              pip install ase==3.22.1 black==22.3.0 pymatgen==2023.1.20
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              pip install pymatgen ase==3.22.1 black==22.3.0
+              pip install pymatgen==2023.5.10 ase==3.22.1 black==22.3.0
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ commands:
               # Install ocp conda env
               source /home/circleci/miniconda/etc/profile.d/conda.sh
               conda activate ocp
-              pip install pymatgen==2023.1.20 ase==3.22.1 black==22.3.0
+              pip install pymatgen ase==3.22.1 black==22.3.0
               pip install pytest-cov==4.0.0 pre-commit==2.10.*
             fi
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The easiest way to install prerequisites is via [conda](https://conda.io/docs/in
 
 * Create a new environment: `conda create -n ocp python=3.9`
 * Activate the newly created environment: `conda activate ocp`
-* Install specific versions of Pymatgen and ASE: `pip install pymatgen==2023.1.20 ase==3.22.1`
+* Install specific versions of Pymatgen and ASE: `pip install pymatgen==2023.5.10 ase==3.22.1`
 * Clone this repo and install with: `pip install -e .`
 
 ## Workflow

--- a/ocdata/structure_generator.py
+++ b/ocdata/structure_generator.py
@@ -118,7 +118,8 @@ class StructureGenerator:
             )
 
         # write files
-        write_surface(self.args, self.slab, self.bulk_index, self.surface_index)
+        if args.skip_surface_inputs:
+            write_surface(self.args, self.slab, self.bulk_index, self.surface_index)
         if self.heur_adslabs:
             self._write_adslabs(self.heur_adslabs, "heur")
         if self.rand_adslabs:
@@ -314,6 +315,12 @@ def parse_args():
         action="store_true",
         default=False,
         help="Do not write out POTCAR/INCAR/KPOINTS for adslabs",
+    )
+    parser.add_argument(
+        "--skip_surface_inputs",
+        action="store_true",
+        default=False,
+        help="Skip writing DFT surface inputs",
     )
     parser.add_argument(
         "--verbose", action="store_true", default=False, help="Log detailed info"

--- a/ocdata/structure_generator.py
+++ b/ocdata/structure_generator.py
@@ -118,7 +118,7 @@ class StructureGenerator:
             )
 
         # write files
-        if args.skip_surface_inputs:
+        if not args.skip_surface_inputs:
             write_surface(self.args, self.slab, self.bulk_index, self.surface_index)
         if self.heur_adslabs:
             self._write_adslabs(self.heur_adslabs, "heur")

--- a/tests/test_adsorbate_slab_config.py
+++ b/tests/test_adsorbate_slab_config.py
@@ -37,7 +37,7 @@ class TestAdslab:
         assert np.all(
             np.isclose(
                 adslab.atoms_list[0].get_positions().mean(0),
-                np.array([6.89162565, 6.13528669, 16.19855907]),
+                np.array([6.2668884, 4.22961421, 16.47458617]),
             )
         )
         assert np.all(

--- a/tests/test_adsorbate_slab_config.py
+++ b/tests/test_adsorbate_slab_config.py
@@ -43,7 +43,7 @@ class TestAdslab:
         assert np.all(
             np.isclose(
                 adslab.atoms_list[1].get_positions().mean(0),
-                np.array([6.86943456, 6.48018977, 16.1635785]),
+                np.array([6.1967168, 4.73603662, 16.46990669]),
             )
         )
 

--- a/tests/test_bulk.py
+++ b/tests/test_bulk.py
@@ -74,8 +74,8 @@ class TestBulk:
             assert slab not in seen
             seen.append(slab)
 
-        # pymatgen-2023.1.20 + ase 3.22.1
-        assert len(slabs) == 15
+        # pymatgen-2023.5.10 + ase 3.22.1
+        assert len(slabs) == 14
 
         with open(self.precomputed_path, "wb") as f:
             pickle.dump(slabs, f)
@@ -86,7 +86,8 @@ class TestBulk:
         precomputed_slabs = self.bulk.get_slabs(
             precomputed_slabs_dir=precomputed_slabs_dir
         )
-        assert len(precomputed_slabs) == 15
+        # pymatgen-2023.5.10 + ase 3.22.1
+        assert len(precomputed_slabs) == 14
 
         slabs = self.bulk.get_slabs()
         assert precomputed_slabs[0] == slabs[0]

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -30,6 +30,6 @@ class TestSlab:
         bulk = Bulk(bulk_id_from_db=100)
         slab = Slab.from_bulk_get_random_slab(bulk)
 
-        assert slab.atoms.get_chemical_formula() == "Sn36"
+        assert slab.atoms.get_chemical_formula() == "Sn48"
         assert slab.millers == (2, 1, 0)
         assert slab.shift == 0.25

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -30,6 +30,6 @@ class TestSlab:
         bulk = Bulk(bulk_id_from_db=100)
         slab = Slab.from_bulk_get_random_slab(bulk)
 
-        assert slab.atoms.get_chemical_formula() == "Sn48"
-        assert slab.millers == (1, 0, 0)
+        assert slab.atoms.get_chemical_formula() == "Sn36"
+        assert slab.millers == (2, 1, 0)
         assert slab.shift == 0.25

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -32,4 +32,4 @@ class TestSlab:
 
         assert slab.atoms.get_chemical_formula() == "Sn48"
         assert slab.millers == (2, 1, 0)
-        assert slab.shift == 0.25
+        assert slab.shift == 0.0833333333333334

--- a/tests/test_slab.py
+++ b/tests/test_slab.py
@@ -30,6 +30,6 @@ class TestSlab:
         bulk = Bulk(bulk_id_from_db=100)
         slab = Slab.from_bulk_get_random_slab(bulk)
 
-        assert slab.atoms.get_chemical_formula() == "Sn36"
+        assert slab.atoms.get_chemical_formula() == "Sn48"
         assert slab.millers == (1, 0, 0)
         assert slab.shift == 0.25


### PR DESCRIPTION
When generating inputs for existing surfaces, we have no desire in writing surface inputs again. Add a flag to skip that here.